### PR TITLE
Fix DatePickerAndroid error when passing "minDate: null"

### DIFF
--- a/Libraries/Components/DatePickerAndroid/DatePickerAndroid.android.js
+++ b/Libraries/Components/DatePickerAndroid/DatePickerAndroid.android.js
@@ -18,7 +18,7 @@ const DatePickerModule = require('NativeModules').DatePickerAndroid;
 function _toMillis(options: Object, key: string) {
   const dateVal = options[key];
   // Is it a Date object?
-  if (typeof dateVal === 'object' && typeof dateVal.getMonth === 'function') {
+  if (dateVal != null && typeof dateVal == 'object' && typeof dateVal.getMonth === 'function') {
     options[key] = dateVal.getTime();
   }
 }


### PR DESCRIPTION
Fixes #21253

It avoids an error when passing an `options` object with `minDate: null`. (see #21253)
Inspired by [isObjectLike ](https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L11771-L11773)from Loadash.

Test Plan:
----------

This [jsbin](https://jsbin.com/hiferipene/1/edit?js,console) allow to test the old and the new `_toMillis` function.

You can observe that `_toMillis` doesn't throw error (fixed) and that if you decomment the `_toMillis_before_pr` call, it will generate an error as before.


Release Notes:
--------------

[ANDROID] [BUGFIX] [DatePickerAndroid] fix error when passing "minDate: null"
